### PR TITLE
Update sidebar styles for responsive layout adjustments

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -147,6 +147,14 @@ header .image-text .header-text{
     transition: var(--trans03);
 }
 
+.sidebar ~ .Inicio {
+    width: calc(100% - 250px);
+}
+
+.sidebar.close ~ .Inicio {
+    width: calc(100% - 90px);
+}
+
 .sidebar.close header .toggle{
     transform: translateY(-50%);
 }


### PR DESCRIPTION
This pull request introduces changes to the `styles.css` file to adjust the width of the `.Inicio` element based on the state of the `.sidebar` element.

Adjustments to element widths:

* [`styles.css`](diffhunk://#diff-380b7b38760dd442e897eb0164c58f6a17da966ccaca6318017a468c163979b1R150-R157): Added CSS rules to set the width of the `.Inicio` element to `calc(100% - 250px)` when the `.sidebar` is open, and to `calc(100% - 90px)` when the `.sidebar` is closed.